### PR TITLE
Fixed BackgroundColor issue from ProgressRadial

### DIFF
--- a/src/AlohaKit/Controls/ProgressRadial/ProgressRadial.cs
+++ b/src/AlohaKit/Controls/ProgressRadial/ProgressRadial.cs
@@ -42,6 +42,22 @@
             animation.Commit(this, "ProgressAngle", length: (uint)250);
         }
 
+        public new static readonly BindableProperty BackgroundColorProperty =
+          BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(ProgressRadial), Colors.White,
+              propertyChanged: (bindableObject, oldValue, newValue) =>
+              {
+                  if (newValue != null && bindableObject is ProgressRadial progressRadial)
+                  {
+                      progressRadial.UpdateBackgroundColor();
+                  }
+              });
+
+        public new Color BackgroundColor
+        {
+            get => (Color)GetValue(BackgroundColorProperty);
+            set => SetValue(BackgroundColorProperty, value);
+        }
+
         public static readonly BindableProperty StrokeColorProperty =
           BindableProperty.Create(nameof(StrokeColor), typeof(Color), typeof(ProgressRadial), Colors.LightGray,
               propertyChanged: (bindableObject, oldValue, newValue) =>
@@ -51,7 +67,6 @@
                       progressRadial.UpdateStrokeColor();
                   }
               });
-
 
         public Color StrokeColor
         {


### PR DESCRIPTION
![TpF97PBUph](https://user-images.githubusercontent.com/20904914/170971838-9accfb45-527b-431d-9a2e-289fe9e3b008.gif)

This PR fixes a bug that didn't allow changing the background color of the ProgressRadial. A BackgroundColor property has been added to the ProgressRadial class with the new operator (so that this property is used instead of the VisualElement's BackgroundColor) so that UpdateBackgroundColor can be called when the BackgroundColor has changed.