### PR TITLE
Add CI Build & Versioning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = crlf
+indent_size = 4
+indent_style = tab
+
+[*.xaml]
+indent_size = 2
+
+[*{.props,.targets}]
+indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Build Package
+
+on:
+	push:
+		branches: [main]
+	pull_request:
+		branches: [main]
+
+jobs:
+	build:
+	name: Build AlohaKit
+	runs-on: windows-latest
+	env:
+		DOTNET_CLI_TELEMETRY_OPTOUT: 1
+	steps:
+		- name: Checkout
+			uses: actions/checkout@v3
+			with:
+				fetch-depth: 0
+
+		- name: Setup .NET Core 6.0
+			uses: actions/setup-dotnet@v2
+			with:
+				dotnet-version: '6.0.x'
+
+		- name: Install .NET MAUI Workload
+			run: dotnet workload install maui
+
+		- name: NuGet Restore
+			run: dotnet restore ./src/AlohaKit
+
+		- name: DotNet Build
+			run: dotnet build ./src/AlohaKit -c Release
+
+		- name: Upload Artifacts
+			uses: actions/upload-artifact@v3
+			with:
+				name: NuGet
+				path: Artifacts/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,45 @@
+<Project>
+
+	<PropertyGroup>
+		<NeutralLanguage>en</NeutralLanguage>
+		<Company>Javier Suárez Ruiz</Company>
+		<Description>A set of .NET MAUI drawn controls.</Description>
+		<PackageProjectUrl>https://github.com/jsuarezruiz/AlohaKit</PackageProjectUrl>
+		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<RepositoryUrl>https://github.com/jsuarezruiz/AlohaKit</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageTags>dotnet,dotnet-maui,maui, controls,drawn-controls,graphics</PackageTags>
+		<PackageIcon>icon.png</PackageIcon>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<Copyright>Javier Suárez Ruiz</Copyright>
+		<Authors>Javier Suárez Ruiz</Authors>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<PackageOutputPath>$(MSBuildThisFileDirectory)Artifacts</PackageOutputPath>
+		<IncludeSymbols>True</IncludeSymbols>
+		<IncludeSource>True</IncludeSource>
+		<ContinuousIntegrationBuild>$(CI)</ContinuousIntegrationBuild>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).trx</VSTestLogger>
+		<VSTestResultsDirectory>$(MSBuildThisFileDirectory)TestResults</VSTestResultsDirectory>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<None Include="$(MSBuildThisFileDirectory)icon.png" Pack="true" PackagePath="\" />
+		<None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="\" />
+		<None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Nerdbank.GitVersioning" 
+											Version="3.5.107"
+											PrivateAssets="all" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub"
+											Version="1.1.1"
+											PrivateAssets="all" />
+	</ItemGroup>
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,15 @@
+<Project>
+
+  <PropertyGroup>
+    <Product>$(AssemblyName) ($(TargetFramework))</Product>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Nuget source link -->
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+
+</Project>

--- a/src/AlohaKit/AlohaKit.csproj
+++ b/src/AlohaKit/AlohaKit.csproj
@@ -5,8 +5,6 @@
 		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.19041</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
-		<ImplicitUsings>enable</ImplicitUsings>
-
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-ios'">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="'$(TargetFramework)' == 'net6.0-android'">21.0</SupportedOSPlatformVersion>
@@ -14,18 +12,7 @@
 		<TargetPlatformMinVersion Condition="$(TargetFramework.Contains('-windows'))">10.0.17763.0</TargetPlatformMinVersion>
 		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 		<Title>AlohaKit</Title>
-		<Company>Javier Suárez Ruiz</Company>
-		<Description>A set of .NET MAUI drawn controls.</Description>
-		<PackageProjectUrl>https://github.com/jsuarezruiz/AlohaKit</PackageProjectUrl>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<RepositoryUrl>https://github.com/jsuarezruiz/AlohaKit</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<PackageTags>dotnet,dotnet-maui,maui, controls,drawn-controls,graphics</PackageTags>
-		<PackageIcon>icon.png</PackageIcon>
-		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<PackageId>AlohaKit</PackageId>
-		<Copyright>Javier Suárez Ruiz</Copyright>
-		<Authors>Javier Suárez Ruiz</Authors>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -33,21 +20,6 @@
 	  <Folder Include="Platforms\iOS\" />
 	  <Folder Include="Platforms\MacCatalyst\" />
 	  <Folder Include="Platforms\Windows\" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <None Include="..\..\icon.png">
-	    <Pack>True</Pack>
-	    <PackagePath>\</PackagePath>
-	  </None>
-	  <None Include="..\..\LICENSE">
-	    <Pack>True</Pack>
-	    <PackagePath>\</PackagePath>
-	  </None>
-	  <None Include="..\..\README.md">
-	    <Pack>True</Pack>
-	    <PackagePath>\</PackagePath>
-	  </None>
 	</ItemGroup>
 
 </Project>

--- a/version.json
+++ b/version.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.0",
+  "buildNumberOffset": 19,
+  "assemblyVersion": {
+    "precision": "revision"
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$"
+  ]
+}


### PR DESCRIPTION
# Description

Adds automatic package versioning with Nerdbank Git Versioning. The Major.Minor can be updated by updating the version.json. 

Adds a CI build using GitHub Actions. This ensures as well that future builds will be built against the current stable release of .NET MAUI instead of a nightly/vNext like what's on NuGet.org currently #15