### PR TITLE
fix public release branch

### DIFF
--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
     "precision": "revision"
   },
   "publicReleaseRefSpec": [
-    "^refs/heads/master$"
+    "^refs/heads/main$"
   ]
 }


### PR DESCRIPTION
# Description

Fixes the Public Release Branch Ref in the version.json so that when the `main` branch is build a normalized version is generated without the git hash.