### PR TITLE
maui dependency hack

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,4 +42,18 @@
 											Version="1.1.1"
 											PrivateAssets="all" />
 	</ItemGroup>
+
+	<ItemGroup>
+		<!--
+			HACK: This is a bug in MAUI GA/SR1 which will be fixed in SR2
+			This will remove these dependencies from being added to the generated NuGet package
+			preventing dependency issues when future versions of MAUI are released.
+			-->
+		<PackageReference Include="Microsoft.Maui.Dependencies" Version="$(MauiVersion)">
+			<PrivateAssets>All</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Maui.Extensions" Version="$(MauiVersion)">
+			<PrivateAssets>All</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
# Description

MAUI currently has a bug in which 2 dependencies are added to the generated NuGet packages for 3rd party libraries like AlohaKit. This provides a workaround to remove these dependencies from the package so that they can be properly referenced by the MAUI SDK. This will prevent users from having issues when future versions (i.e. SR2) are released while still using a build of AlohaKit which was built against SR1.