### PR TITLE
add release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,33 +7,13 @@ on:
     branches: [main]
 
 jobs:
-  build:
-    name: Build-AlohaKit
-    runs-on: windows-latest
-    env:
-      DOTNET_CLI_TELEMETRY_OPTOUT: 1
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: Setup .NET Core 6.0
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '6.0.x'
-
-    - name: Install .NET MAUI Workload
-      run: dotnet workload install maui
-
-    - name: NuGet Restore
-      run: dotnet restore ./src/AlohaKit
-
-    - name: DotNet Build
-      run: dotnet build ./src/AlohaKit -c Release
-
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: NuGet
-        path: Artifacts/
+   build:
+    uses: avantipoint/workflow-templates/.github/workflows/dotnet-build.yml@master
+    permissions:
+      statuses: write
+      checks: write
+    with:
+      name: AlohaKit
+      solution-path: ./src/AlohaKit
+      install-workload: maui
+      run-tests: false

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,11 @@
+name: Publish AlohaKit Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-release:
+    uses: avantipoint/workflow-templates/.github/workflows/deploy-nuget-from-release.yml@master
+    secrets:
+      apiKey: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -1,0 +1,24 @@
+name: Start NuGet Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: avantipoint/workflow-templates/.github/workflows/dotnet-build.yml@master
+    permissions:
+      statuses: write
+      checks: write
+    with:
+      name: AlohaKit
+      solution-path: ./src/AlohaKit
+      install-workload: maui
+      run-tests: false
+
+  release:
+    uses: avantipoint/workflow-templates/.github/workflows/generate-release.yml@master
+    needs: [build]
+    permissions:
+      contents: write
+    with:
+      package-name: AlohaKit


### PR DESCRIPTION
# Description

This simplifies the CI workflow with the AvantiPoint Workflow Templates, and adds 2 new workflows.

1) `start-release` - This is a manually triggered workflow. When triggered it will create a build the same as the CI workflow, After building the library it will create a draft Release, auto-generate release notes, and upload the artifacts
2) `publish-release` - This is triggered automatically when the Release is published. This will download the artifacts from the release and then publish them to nuget.org. 

**NOTE:** Before the publish release workflow is run you will need to Generate / Add a NuGet API Key to the Repo Secrets with the key `NUGET_API_KEY`