### PR TITLE
Add default brushes to controls to prevent rendering issues

### DIFF
--- a/src/AlohaKit/Controls/LinearGauge/LinearGauge.cs
+++ b/src/AlohaKit/Controls/LinearGauge/LinearGauge.cs
@@ -20,7 +20,7 @@
         public LinearGaugeDrawable LinearGaugeDrawable { get; set; }
        
         public static readonly new BindableProperty BackgroundProperty =  
-            BindableProperty.Create(nameof(Background), typeof(Brush), typeof(Button), null,
+            BindableProperty.Create(nameof(Background), typeof(Brush), typeof(Button), new SolidColorBrush(Colors.Pink),
                 propertyChanged: (bindableObject, oldValue, newValue) =>
                 {
                     if (newValue != null && bindableObject is LinearGauge linearGauge)

--- a/src/AlohaKit/Controls/NumericUpDown/NumericUpDown.cs
+++ b/src/AlohaKit/Controls/NumericUpDown/NumericUpDown.cs
@@ -53,7 +53,7 @@ namespace AlohaKit.Controls
         }
 
         public static readonly BindableProperty MinimumColorProperty =
-            BindableProperty.Create(nameof(MinimumColor), typeof(Brush), typeof(NumericUpDown), null,
+            BindableProperty.Create(nameof(MinimumColor), typeof(Brush), typeof(NumericUpDown), new SolidColorBrush(Colors.Green),
                 propertyChanged: (bindableObject, oldValue, newValue) =>
                 {
                     if (newValue != null && bindableObject is NumericUpDown numericUpDown)
@@ -69,7 +69,7 @@ namespace AlohaKit.Controls
         }
 
         public static readonly BindableProperty MaximumColorProperty =
-            BindableProperty.Create(nameof(MaximumColor), typeof(Brush), typeof(NumericUpDown), null,
+            BindableProperty.Create(nameof(MaximumColor), typeof(Brush), typeof(NumericUpDown), new SolidColorBrush(Colors.Red),
                 propertyChanged: (bindableObject, oldValue, newValue) =>
                 {
                     if (newValue != null && bindableObject is NumericUpDown numericUpDown)
@@ -235,6 +235,8 @@ namespace AlohaKit.Controls
                 UpdateMinimum();
                 UpdateMaximum();
                 UpdateValue();
+				UpdateMinimumColor();
+				UpdateMaximumColor();
             }
         }
 

--- a/src/AlohaKit/Controls/SegmentedControl/SegmentedControl.cs
+++ b/src/AlohaKit/Controls/SegmentedControl/SegmentedControl.cs
@@ -22,7 +22,7 @@ namespace AlohaKit.Controls
         public SegmentedControlDrawable SegmentedControlDrawable { get; set; }
 
         public static readonly new BindableProperty BackgroundProperty =
-          BindableProperty.Create(nameof(Background), typeof(Brush), typeof(SegmentedControl), null,
+          BindableProperty.Create(nameof(Background), typeof(Brush), typeof(SegmentedControl), new SolidColorBrush(Colors.Gray),
              propertyChanged: (bindableObject, oldValue, newValue) =>
              {
                  if (newValue != null && bindableObject is SegmentedControl segmentedControl)
@@ -38,7 +38,7 @@ namespace AlohaKit.Controls
         }
 
         public static readonly BindableProperty ActiveBackgroundProperty =  
-            BindableProperty.Create(nameof(ActiveBackground), typeof(Brush), typeof(SegmentedControl), null,
+            BindableProperty.Create(nameof(ActiveBackground), typeof(Brush), typeof(SegmentedControl), new SolidColorBrush(Colors.Pink),
                 propertyChanged: (bindableObject, oldValue, newValue) =>
                 {
                     if (newValue != null && bindableObject is SegmentedControl segmentedControl)

--- a/src/AlohaKit/Controls/Slider/Slider.cs
+++ b/src/AlohaKit/Controls/Slider/Slider.cs
@@ -85,7 +85,7 @@
         }
 
         public static readonly BindableProperty MinimumBrushProperty =
-            BindableProperty.Create(nameof(MinimumBrush), typeof(Brush), typeof(Slider), null,
+            BindableProperty.Create(nameof(MinimumBrush), typeof(Brush), typeof(Slider), new SolidColorBrush(Colors.Gray),
                 propertyChanged: (bindableObject, oldValue, newValue) =>
                 {
                     if (newValue != null && bindableObject is Slider slider)
@@ -101,7 +101,7 @@
         }
 
         public static readonly BindableProperty MaximumBrushProperty =
-            BindableProperty.Create(nameof(MaximumBrush), typeof(Brush), typeof(Slider), null,
+            BindableProperty.Create(nameof(MaximumBrush), typeof(Brush), typeof(Slider), new SolidColorBrush(Colors.Black),
                 propertyChanged: (bindableObject, oldValue, newValue) =>
                 {
                     if (newValue != null && bindableObject is Slider slider)
@@ -117,7 +117,7 @@
         }
 
         public static readonly BindableProperty ThumbBrushProperty =
-            BindableProperty.Create(nameof(ThumbBrush), typeof(Brush), typeof(Slider), null,
+            BindableProperty.Create(nameof(ThumbBrush), typeof(Brush), typeof(Slider), new SolidColorBrush(Colors.Pink),
                 propertyChanged: (bindableObject, oldValue, newValue) =>
                 {
                     if (newValue != null && bindableObject is Slider slider)

--- a/src/AlohaKit/Controls/ToggleSwitch/ToggleSwitch.cs
+++ b/src/AlohaKit/Controls/ToggleSwitch/ToggleSwitch.cs
@@ -26,7 +26,7 @@ namespace AlohaKit.Controls
         public ToggleSwitchDrawable ToggleSwitchDrawable { get; set; }
 
         public static readonly new BindableProperty BackgroundProperty =
-           BindableProperty.Create(nameof(Background), typeof(Brush), typeof(ToggleSwitch), null,
+           BindableProperty.Create(nameof(Background), typeof(Brush), typeof(ToggleSwitch), new SolidColorBrush(Colors.Gray),
                propertyChanged: (bindableObject, oldValue, newValue) =>
                {
                    if (newValue != null && bindableObject is ToggleSwitch toggleSwitch)
@@ -42,7 +42,7 @@ namespace AlohaKit.Controls
         }
 
         public static readonly BindableProperty ThumbBrushProperty =
-           BindableProperty.Create(nameof(ThumbBrush), typeof(Brush), typeof(ToggleSwitch), null,
+           BindableProperty.Create(nameof(ThumbBrush), typeof(Brush), typeof(ToggleSwitch), new SolidColorBrush(Colors.Pink),
                propertyChanged: (bindableObject, oldValue, newValue) =>
                {
                    if (newValue != null && bindableObject is ToggleSwitch toggleSwitch)


### PR DESCRIPTION
### Description of change
This PR adds default brush initialization to several controls that previously lacked them. Without defined brushes or colors, some controls — such as the `Slider` — were not rendering at all.

If i define controls something like this

```xaml
 <controls:Slider />
 <controls:ToggleSwitch />
 <controls:SegmentedControl>
   <controls:SegmentedControl.ItemsSource>
     <x:Array Type="{x:Type x:String}">
       <x:String>Option 1</x:String>
       <x:String>Option 2</x:String>
       <x:String>Option 3</x:String>
     </x:Array>
   </controls:SegmentedControl.ItemsSource>
 </controls:SegmentedControl>
 <controls:NumericUpDown  />
 <controls:LinearGauge Value="50"  />
```
The slider is not visible at all, and other controls have issues too.. 

<img src="https://github.com/user-attachments/assets/ab423daf-c078-48e1-818e-219d4c1ea83b" alt="Mobile Screenshot" width="250" height="500" />

**After Fix**

<img src="https://github.com/user-attachments/assets/2a901a71-43db-4953-be72-6b55fa578879" alt="Mobile Screenshot" width="250" height="500" />

Fixes #64

