### PR TITLE
Adding is reversed property

### DIFF
--- a/src/AlohaKit.Gallery/Views/SliderView.xaml
+++ b/src/AlohaKit.Gallery/Views/SliderView.xaml
@@ -125,8 +125,17 @@
             </StackLayout>
         </StackLayout>
         <VerticalStackLayout Grid.Row="3">
-            <Label HorizontalOptions="Center" Text="{Binding Source={x:Reference Slider}, Path=Value}" />
-            <controls:Slider x:Name="Slider" />
+            <Label HorizontalOptions="Center"
+                   Text="{Binding Source={x:Reference Slider}, Path=Value}"/>
+            <controls:Slider x:Name="Slider"
+                             IsReversed="{Binding IsChecked, Source={x:Reference IsReversedCheckBox}, x:DataType=controls:CheckBox}"/>
+        </VerticalStackLayout>
+        <VerticalStackLayout Grid.Row="4"
+                             Margin="20"
+                             Spacing="10"
+                             HorizontalOptions="Center">
+            <Label Text="Is Reversed"/>
+            <controls:CheckBox x:Name="IsReversedCheckBox"/>
         </VerticalStackLayout>
     </Grid>
 </ContentPage>


### PR DESCRIPTION
This PR introduces a new isReversed property. When enabled, it reverses the direction in which values are added and rendered. This allows for greater flexibility in UI design, especially in cases where the slider needs to operate from right to left.

**Changes:**

- Added isReversed boolean property
- Updated rendering logic to handle reversed direction
- Ensured compatibility with existing props and behavior

Let me know if any adjustments are needed